### PR TITLE
More router #149

### DIFF
--- a/firmware_tests/demo_1.py
+++ b/firmware_tests/demo_1.py
@@ -1,6 +1,7 @@
 from server.test import FirmwareTest
 import os
 import time
+from jsonschema import validate
 
 
 class ConnectionTest(FirmwareTest):
@@ -14,6 +15,9 @@ class ConnectionTest(FirmwareTest):
 
     def test_self_router(self):
         assert self.remote_system.id == 0
+
+    def test_all_routers(self):
+        assert len(self.all_routers) >= 1
 
     def test_ping_local(self):
         response = os.system("ping -t 5 -c 1 " + "localhost")

--- a/firmware_tests/demo_1.py
+++ b/firmware_tests/demo_1.py
@@ -1,7 +1,6 @@
 from server.test import FirmwareTest
 import os
 import time
-from jsonschema import validate
 
 
 class ConnectionTest(FirmwareTest):

--- a/network/remote_system.py
+++ b/network/remote_system.py
@@ -46,7 +46,10 @@ class RemoteSystem(metaclass=ABCMeta):
 
 class RemoteSystemJob(metaclass=ABCMeta):
     """
-    An extended Thread for job which are associated with an RemoteSystem.
+    The abstract class for Tasks which are executed in the specific namespace of a remote system.
+
+    It has the vars self/cls.remote_system and self/cls.all_routers.
+
     The Server handles the job and is working in the following order:
         - data = job.pre_process(Server)
         -    job.prepare(remote_sys)
@@ -72,11 +75,12 @@ class RemoteSystemJob(metaclass=ABCMeta):
         logging.debug("%sPrepare job", LoggerSetup.get_log_deep(5))
         self.remote_system = remote_sys
         self.all_routers = routers
-        RemoteSystemJob._prepare(remote_sys)
+        RemoteSystemJob._prepare(remote_sys, routers)
 
     @classmethod
-    def _prepare(cls, remote_sys: RemoteSystem):
+    def _prepare(cls, remote_sys: RemoteSystem, routers: List):
         cls.remote_system = remote_sys
+        cls.all_routers = routers
 
     @abstractstaticmethod
     def pre_process(self, server) -> {}:

--- a/network/remote_system.py
+++ b/network/remote_system.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractproperty, abstractmethod, abstractstaticmethod
 from log.loggersetup import LoggerSetup
 import logging
+from typing import List
 # from server.server import Server
 
 
@@ -55,19 +56,22 @@ class RemoteSystemJob(metaclass=ABCMeta):
     """""
     def __init__(self):
         self.remote_system = None
+        self.all_routers = None
         self.__return_data = None
 
     def __str__(self):
         return self.__class__.__name__  # TODO: __str__ remotesystemjob"
 
-    def prepare(self, remote_sys: RemoteSystem) -> None:
+    def prepare(self, remote_sys: RemoteSystem, routers: List) -> None:
         """
         Prepares the system job before the run method will started
 
         :param remote_sys: the RemoteSystem which are connected to this job
+        :param routers: all routers as a copy
         """
         logging.debug("%sPrepare job", LoggerSetup.get_log_deep(5))
         self.remote_system = remote_sys
+        self.all_routers = routers
         RemoteSystemJob._prepare(remote_sys)
 
     @classmethod

--- a/server/server.py
+++ b/server/server.py
@@ -385,11 +385,11 @@ class Server(ServerProxy):
             # logging.debug(str(cls._running_task), 3)
 
     @classmethod
-    def _execute_job(cls, job: RemoteSystemJob, remote_sys: RemoteSystem) -> {}:
+    def _execute_job(cls, job: RemoteSystemJob, remote_sys: RemoteSystem, routers: List[Router]) -> {}:
         logging.debug("%sExecute job " + str(job) + " on Router(" + str(remote_sys.id) + ")",
                       LoggerSetup.get_log_deep(2))
         setproctitle(str(remote_sys.id) + " - " + str(job))
-        job.prepare(remote_sys)
+        job.prepare(remote_sys, routers)
 
         cls.__setns(remote_sys)
         try:
@@ -400,7 +400,7 @@ class Server(ServerProxy):
         return result
 
     @classmethod
-    def _execute_test(cls, test: FirmwareTestClass, router: Router) -> TestResult:
+    def _execute_test(cls, test: FirmwareTestClass, router: Router, routers: List[Router]) -> TestResult:
         if not isinstance(router, Router):
             raise ValueError("Chosen Router is not a real Router...")
         # proofed: this method runs in other process as the server
@@ -412,7 +412,7 @@ class Server(ServerProxy):
         # prepare all test cases
         for test_case in test_suite:
             logging.debug("%sTestCase " + str(test_case), LoggerSetup.get_log_deep(4))
-            test_case.prepare(router)
+            test_case.prepare(router, routers)
 
         result = TestResult()
 
@@ -445,7 +445,7 @@ class Server(ServerProxy):
         """
         logging.debug("%sWait for test" + str(test), LoggerSetup.get_log_deep(2))
         try:
-            async_result = cls._task_pool.apply_async(func=cls._execute_test, args=(test, router))
+            async_result = cls._task_pool.apply_async(func=cls._execute_test, args=(test, router, cls._routers))
             result = async_result.get(300)  # wait 5 minutes or raise an TimeoutError
             logging.debug("%sTest done " + str(test), LoggerSetup.get_log_deep(1))
             logging.debug("%sFrom " + str(router), LoggerSetup.get_log_deep(2))
@@ -480,7 +480,7 @@ class Server(ServerProxy):
         :param job: job to execute
         :param remote_sys: the RemoteSystem
         """
-        async_result = cls._task_pool.apply_async(func=cls._execute_job, args=(job, remote_sys))
+        async_result = cls._task_pool.apply_async(func=cls._execute_job, args=(job, remote_sys, cls._routers))
         result = async_result.get(300)  # wait 5 minutes or raise an TimeoutError
         logging.debug("%sJob done " + str(job), LoggerSetup.get_log_deep(1))
         logging.debug("%sAt Router(" + str(remote_sys.id) + ")", LoggerSetup.get_log_deep(2))


### PR DESCRIPTION
Nun sind alle routers über self.all_routers erreichbar in den Tests und Jobs.


Following tickets are finished:
resolved #149 


tested on Pi:
- [x] test_R_Server_VLAN.py
- [x] test_AP_*.py
- [x] test_A_Server_2.py