### PR TITLE
Systemctl stop bugfix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ Description=Freifunk Testserver
 After=syslog.target" >> "$file"
 
 echo "[Service]
+KillSignal=SIGINT
 Type=simple
 ExecStart=$DIR/start_server.py" >> "$file"
 


### PR DESCRIPTION
_systemctl stop fftserver_ funktioniert nun wieder richtig.


Following tickets are finished:
resolved #192


tested on Pi:
- [x] test_R_Server_VLAN.py
- [x] test_AP_*.py
- [x] test_A_Server_2.py

