### PR TITLE
test_cli waits now on until the server is online

### DIFF
--- a/framework_unittests/test_A_cli.py
+++ b/framework_unittests/test_A_cli.py
@@ -5,6 +5,7 @@ from server.server import Server
 from multiprocessing import Process
 from server.ipc import IPC
 import os
+from framework_unittests.test_A_Server_2 import block_until_server_is_online
 
 
 class TestCaseParser(unittest.TestCase):
@@ -171,7 +172,7 @@ class TestCLItoServerConnection(unittest.TestCase):
     def setUpClass(cls):
         #  starts the IPC server in another(!) process
         cls.proc = Process(target=TestCLItoServerConnection.serverStartWithParams, args=()).start()
-        time.sleep(2)
+        block_until_server_is_online()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
_test_A_cli.py_ hat manchmal zu früh die Testfälle gestartet und ist somit fehlgeschlagen.

tested on Pi:
- [x] test_R_Server_VLAN.py
- [x] test_AP_*.py
- [x] test_A_Server_2.py

